### PR TITLE
Clear video background after 5 seconds with fade transition

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import Navigation from "@/components/Navigation";
@@ -19,6 +19,15 @@ import {
 } from "lucide-react";
 
 const Index = () => {
+  const [showVideo, setShowVideo] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowVideo(false);
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, []);
   return (
     <div className="min-h-screen bg-midnight-black text-soft-gray">
       <Navigation />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -36,17 +36,6 @@ const Index = () => {
       <section className="relative pt-20 pb-32 px-4 sm:px-6 lg:px-8 overflow-hidden">
         {/* Video Background */}
         <video
-          ref={(video) => {
-            if (video) {
-              const handleLoadedData = () => {
-                setTimeout(() => {
-                  video.pause();
-                }, 5000); // Pause after 5 seconds
-              };
-              video.addEventListener('loadeddata', handleLoadedData);
-              return () => video.removeEventListener('loadeddata', handleLoadedData);
-            }
-          }}
           autoPlay={true}
           muted={true}
           loop={false}
@@ -55,7 +44,9 @@ const Index = () => {
           preload="auto"
           webkit-playsinline="true"
           data-object-fit="cover"
-          className="absolute inset-0 w-full h-full object-cover z-0"
+          className={`absolute inset-0 w-full h-full object-cover z-0 transition-opacity duration-1000 ${
+            showVideo ? 'opacity-100' : 'opacity-0'
+          }`}
           style={{
             width: '100%',
             height: '100%',


### PR DESCRIPTION
## Purpose
User requested to clear the background video after 5 seconds of playback on the website, replacing the previous pause behavior with a complete background removal.

## Code changes
- Added React state management with `useState` and `useEffect` hooks to control video visibility
- Replaced video pause logic with opacity-based fade transition using CSS classes
- Implemented 5-second timer that sets video opacity to 0 with smooth 1-second transition
- Removed previous video ref and event listener approach in favor of state-driven visibility control

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cd91ee31e7774668892936f16e1e330f/pulse-realm)

👀 [Preview Link](https://cd91ee31e7774668892936f16e1e330f-pulse-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cd91ee31e7774668892936f16e1e330f</projectId>-->
<!--<branchName>pulse-realm</branchName>-->