### PR TITLE
Add publisher directory with hero section and search

### DIFF
--- a/api/publishers.ts
+++ b/api/publishers.ts
@@ -64,5 +64,7 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   const slice = filtered.slice(cursor, cursor + limit);
   const nextCursor = cursor + limit < total ? cursor + limit : null;
 
+  // Cache for 300s with stale-while-revalidate
+  res.setHeader?.("Cache-Control", "public, max-age=0, s-maxage=300, stale-while-revalidate=300");
   res.status(200).json({ items: slice, nextCursor, total });
 }

--- a/api/publishers.ts
+++ b/api/publishers.ts
@@ -1,0 +1,68 @@
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const q = (req.query.q as string | undefined)?.toLowerCase() || "";
+  const category = (req.query.category as string | undefined) || "";
+  const limit = Math.max(1, Math.min(100, parseInt((req.query.limit as string) || "24", 10)));
+  const cursor = Math.max(0, parseInt((req.query.cursor as string) || "0", 10));
+
+  type Publisher = {
+    id: string;
+    name: string;
+    domain: string;
+    category: "Campus" | "Local" | "National" | "Global";
+    tagline?: string;
+  };
+
+  const data: Publisher[] = [
+    // National
+    { id: "nytimes", name: "The New York Times", domain: "nytimes.com", category: "National", tagline: "All the News That's Fit to Print" },
+    { id: "washpost", name: "The Washington Post", domain: "washingtonpost.com", category: "National", tagline: "Democracy Dies in Darkness" },
+    { id: "wsj", name: "The Wall Street Journal", domain: "wsj.com", category: "National" },
+    { id: "usatoday", name: "USA Today", domain: "usatoday.com", category: "National" },
+    { id: "npr", name: "NPR", domain: "npr.org", category: "National" },
+    // Global
+    { id: "bbc", name: "BBC News", domain: "bbc.com", category: "Global" },
+    { id: "guardian", name: "The Guardian", domain: "theguardian.com", category: "Global" },
+    { id: "reuters", name: "Reuters", domain: "reuters.com", category: "Global" },
+    { id: "aljazeera", name: "Al Jazeera", domain: "aljazeera.com", category: "Global" },
+    { id: "ap", name: "Associated Press", domain: "apnews.com", category: "Global" },
+    // Local
+    { id: "latimes", name: "Los Angeles Times", domain: "latimes.com", category: "Local" },
+    { id: "sfchron", name: "San Francisco Chronicle", domain: "sfchronicle.com", category: "Local" },
+    { id: "chitrib", name: "Chicago Tribune", domain: "chicagotribune.com", category: "Local" },
+    { id: "seattletimes", name: "The Seattle Times", domain: "seattletimes.com", category: "Local" },
+    { id: "bostonglobe", name: "The Boston Globe", domain: "bostonglobe.com", category: "Local" },
+    // Campus
+    { id: "dailycal", name: "The Daily Californian", domain: "dailycal.org", category: "Campus" },
+    { id: "thedp", name: "The Daily Pennsylvanian", domain: "thedp.com", category: "Campus" },
+    { id: "crimson", name: "The Harvard Crimson", domain: "thecrimson.com", category: "Campus" },
+    { id: "yalenews", name: "Yale Daily News", domain: "yaledailynews.com", category: "Campus" },
+    { id: "stanforddaily", name: "The Stanford Daily", domain: "stanforddaily.com", category: "Campus" },
+    // More Local/National/Global for pagination depth
+    { id: "denverpost", name: "The Denver Post", domain: "denverpost.com", category: "Local" },
+    { id: "phillyinquirer", name: "The Philadelphia Inquirer", domain: "inquirer.com", category: "Local" },
+    { id: "houchron", name: "Houston Chronicle", domain: "houstonchronicle.com", category: "Local" },
+    { id: "dallasnews", name: "The Dallas Morning News", domain: "dallasnews.com", category: "Local" },
+    { id: "miamiherald", name: "Miami Herald", domain: "miamiherald.com", category: "Local" },
+    { id: "economist", name: "The Economist", domain: "economist.com", category: "Global" },
+    { id: "ft", name: "Financial Times", domain: "ft.com", category: "Global" },
+    { id: "bloomberg", name: "Bloomberg", domain: "bloomberg.com", category: "Global" },
+    { id: "axios", name: "Axios", domain: "axios.com", category: "National" },
+    { id: "politico", name: "POLITICO", domain: "politico.com", category: "National" }
+  ];
+
+  const filtered = data.filter((p) => {
+    const matchesQuery = q ? (p.name.toLowerCase().includes(q) || p.domain.includes(q)) : true;
+    const matchesCategory = category ? p.category.toLowerCase() === category.toLowerCase() : true;
+    return matchesQuery && matchesCategory;
+  });
+
+  const total = filtered.length;
+  const slice = filtered.slice(cursor, cursor + limit);
+  const nextCursor = cursor + limit < total ? cursor + limit : null;
+
+  res.status(200).json({ items: slice, nextCursor, total });
+}

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -15,6 +15,7 @@ import Universities from "./pages/Universities";
 import About from "./pages/About";
 import Pricing from "./pages/Pricing";
 import PublisherList from "./pages/PublisherList";
+import PublisherListStatic from "./pages/PublisherListStatic";
 import Blog from "./pages/Blog";
 import Contact from "./pages/Contact";
 import CampusEligibility from "./pages/CampusEligibility";

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -40,6 +40,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/students" element={<Students />} />
           <Route path="/publishers" element={<Publishers />} />
+          <Route path="/publisher-list" element={<PublisherList />} />
           <Route path="/our-publishers" element={<OurPublishers />} />
           <Route path="/universities" element={<Universities />} />
           <Route path="/about" element={<About />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -14,6 +14,7 @@ import OurPublishers from "./pages/OurPublishers";
 import Universities from "./pages/Universities";
 import About from "./pages/About";
 import Pricing from "./pages/Pricing";
+import PublisherList from "./pages/PublisherList";
 import Blog from "./pages/Blog";
 import Contact from "./pages/Contact";
 import CampusEligibility from "./pages/CampusEligibility";

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -42,6 +42,7 @@ const App = () => (
           <Route path="/students" element={<Students />} />
           <Route path="/publishers" element={<Publishers />} />
           <Route path="/publisher-list" element={<PublisherList />} />
+          <Route path="/publisher-list-static" element={<PublisherListStatic />} />
           <Route path="/our-publishers" element={<OurPublishers />} />
           <Route path="/universities" element={<Universities />} />
           <Route path="/about" element={<About />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from "@/lib/auth";
 import Index from "./pages/Index";
 import Students from "./pages/Students";
 import Publishers from "./pages/Publishers";
+import OurPublishers from "./pages/OurPublishers";
 import Universities from "./pages/Universities";
 import About from "./pages/About";
 import Pricing from "./pages/Pricing";
@@ -38,6 +39,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/students" element={<Students />} />
           <Route path="/publishers" element={<Publishers />} />
+          <Route path="/our-publishers" element={<OurPublishers />} />
           <Route path="/universities" element={<Universities />} />
           <Route path="/about" element={<About />} />
           <Route path="/pricing" element={<Pricing />} />

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -43,9 +43,9 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
   // Navigation links for non-authenticated users (marketing pages)
   const publicNavigationLinks = [
     { path: "/students", label: "Students" },
+    { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
-    { path: "/publishers", label: "Publishers" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -29,7 +29,8 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
   };
 
   const isCurrentPage = (path: string) => {
-    return location.pathname === path;
+    // Consider the route active if the current pathname equals or starts with the path
+    return location.pathname === path || location.pathname.startsWith(path + (path.endsWith('/') ? '' : ''));
   };
 
   const getLinkClasses = (path: string) => {
@@ -46,7 +47,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
     { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
-    { path: "/publisher-list", label: "Publisher List" },
+    { path: "/publisher-list-static", label: "Publisher List" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -46,6 +46,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
     { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
+    { path: "/publisher-list", label: "Publisher List" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -43,9 +43,9 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
   // Navigation links for non-authenticated users (marketing pages)
   const publicNavigationLinks = [
     { path: "/students", label: "Students" },
-    { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
+    { path: "/publishers", label: "Publishers" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, User, LogOut, Settings, BarChart3, ChevronDown, ChevronRight } from "lucide-react";
 import { useAuth } from "@/lib/auth";
-import { useState, useRef, useEffect, useCallback } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X, User, LogOut, Settings, BarChart3 } from "lucide-react";
+import { Menu, X, User, LogOut, Settings, BarChart3, ChevronDown, ChevronRight } from "lucide-react";
 import { useAuth } from "@/lib/auth";
+import { useState, useRef, useEffect, useCallback } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X, User, LogOut, Settings, BarChart3, ChevronDown, ChevronRight } from "lucide-react";
+import { Menu, X, User, LogOut, Settings, BarChart3 } from "lucide-react";
 import { useAuth } from "@/lib/auth";
 import {
   DropdownMenu,
@@ -60,39 +60,6 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
   // Choose which navigation links to show
   const navigationLinks = isAuthenticated ? authenticatedNavigationLinks : publicNavigationLinks;
 
-  // Publishers dropdown state and refs
-  const [publishersOpen, setPublishersOpen] = useState(false);
-  const [mobilePublishersOpen, setMobilePublishersOpen] = useState(false);
-  const publishersRef = useRef<HTMLDivElement | null>(null);
-
-  const publishersFilters = [
-    { label: "All Publishers", href: "/publishers", category: "All" },
-    { label: "Campus", href: "/publishers?category=Campus", category: "Campus" },
-    { label: "Local", href: "/publishers?category=Local", category: "Local" },
-    { label: "National", href: "/publishers?category=National", category: "National" },
-    { label: "Global", href: "/publishers?category=Global", category: "Global" },
-  ];
-
-  useEffect(() => {
-    function onDocClick(e: MouseEvent) {
-      const target = e.target as Node;
-      if (publishersRef.current && !publishersRef.current.contains(target)) {
-        setPublishersOpen(false);
-      }
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        setPublishersOpen(false);
-        setMobilePublishersOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDocClick);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, []);
 
   return (
     <nav className="bg-midnight-black/95 backdrop-blur-sm sticky top-0 z-50 border-b border-soft-gray/10">
@@ -109,73 +76,12 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8 relative">
-            {navigationLinks.map((link) => {
-              // Special-case the publishers item to show a hover dropdown
-              if (link.path === "/publishers") {
-                return (
-                  <div
-                    key={link.path}
-                    className="relative"
-                    onMouseEnter={() => setPublishersOpen(true)}
-                    onMouseLeave={() => setPublishersOpen(false)}
-                    onFocus={() => setPublishersOpen(true)}
-                  >
-                    <div className="flex items-center gap-2">
-                      <Link
-                        to={link.path}
-                        className={location.pathname.startsWith('/publishers') ? `${getLinkClasses(link.path)} text-electric-blue` : getLinkClasses(link.path)}
-                        onClick={() => { try { window.analytics?.track('nav_publishers_click'); } catch(e) {} }}
-                      >
-                        {link.label}
-                      </Link>
-                      <button
-                        aria-haspopup="true"
-                        aria-expanded={publishersOpen}
-                        onClick={() => setPublishersOpen((s) => !s)}
-                        className="text-soft-gray/70 hover:text-soft-gray p-1"
-                      >
-                        <ChevronDown className="w-4 h-4" />
-                      </button>
-                    </div>
-
-                    {/* Dropdown panel */}
-                    {publishersOpen && (
-                      <div
-                        ref={publishersRef}
-                        role="menu"
-                        aria-label="Publishers filters"
-                        className="absolute left-0 mt-2 w-56 bg-midnight-black/95 border border-soft-gray/10 rounded-lg shadow-lg py-2 z-50"
-                      >
-                        {publishersFilters.map((f) => (
-                          <Link
-                            key={f.label}
-                            to={f.href}
-                            role="menuitem"
-                            onClick={() => { try { window.analytics?.track('nav_publishers_filter', { category: f.category || 'All' }); } catch (e) {} setPublishersOpen(false); }}
-                            className="block px-4 py-2 text-soft-gray hover:text-electric-blue text-md"
-                          >
-                            <div className="flex justify-between items-center">
-                              <span>{f.label}</span>
-                              {typeof f.stat === 'number' && (
-                                <span className="ml-2 text-xs text-soft-gray/60">• {f.stat}</span>
-                              )}
-                            </div>
-                          </Link>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              }
-
-              // Default link rendering
-              return (
-                <Link key={link.path} to={link.path} className={getLinkClasses(link.path)}>
-                  {link.label}
-                </Link>
-              );
-            })}
+          <div className="hidden md:flex items-center space-x-8">
+            {navigationLinks.map((link) => (
+              <Link key={link.path} to={link.path} className={getLinkClasses(link.path)}>
+                {link.label}
+              </Link>
+            ))}
           </div>
 
           {/* Desktop CTA */}
@@ -264,43 +170,16 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
           <div className="fixed top-14 left-0 right-0 bg-midnight-black/95 backdrop-blur-md z-40 md:hidden">
             <div className="max-w-8xl mx-auto px-4 py-8">
               <div className="flex flex-col space-y-6">
-                {navigationLinks.map((link) => {
-                  if (link.path === '/publishers') {
-                    return (
-                      <div key="mobile-publishers" className="w-full">
-                        <button
-                          onClick={() => setMobilePublishersOpen((s) => !s)}
-                          className="w-full flex items-center justify-between text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
-                          aria-expanded={mobilePublishersOpen}
-                          aria-controls="mobile-publishers-panel"
-                        >
-                          <span>{link.label}</span>
-                          <ChevronRight className={`w-5 h-5 transform transition-transform ${mobilePublishersOpen ? 'rotate-90' : ''}`} />
-                        </button>
-                        {mobilePublishersOpen && (
-                          <div id="mobile-publishers-panel" className="pl-4 mt-2 space-y-2">
-                            {publishersFilters.map((f) => (
-                              <Link key={f.label} to={f.href} onClick={() => { closeMenu(); try { window.analytics?.track('nav_publishers_filter', { category: f.category || 'All' }); } catch(e) {} }} className="block text-soft-gray/80 hover:text-soft-gray py-2">
-                                {f.label}
-                              </Link>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <Link
-                      key={link.path}
-                      to={link.path}
-                      className="text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
-                      onClick={closeMenu}
-                    >
-                      {link.label}
-                    </Link>
-                  );
-                })}
+                {navigationLinks.map((link) => (
+                  <Link
+                    key={link.path}
+                    to={link.path}
+                    className="text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
+                    onClick={closeMenu}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
 
                 {/* Mobile CTA */}
                 <div className="pt-6 border-t border-soft-gray/10">

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -76,16 +76,73 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
-            {navigationLinks.map((link) => (
-              <Link
-                key={link.path}
-                to={link.path}
-                className={getLinkClasses(link.path)}
-              >
-                {link.label}
-              </Link>
-            ))}
+          <div className="hidden md:flex items-center space-x-8 relative">
+            {navigationLinks.map((link) => {
+              // Special-case the publishers item to show a hover dropdown
+              if (link.path === "/publishers") {
+                return (
+                  <div
+                    key={link.path}
+                    className="relative"
+                    onMouseEnter={() => setPublishersOpen(true)}
+                    onMouseLeave={() => setPublishersOpen(false)}
+                    onFocus={() => setPublishersOpen(true)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Link
+                        to={link.path}
+                        className={location.pathname.startsWith('/publishers') ? `${getLinkClasses(link.path)} text-electric-blue` : getLinkClasses(link.path)}
+                        onClick={() => { try { window.analytics?.track('nav_publishers_click'); } catch(e) {} }}
+                      >
+                        {link.label}
+                      </Link>
+                      <button
+                        aria-haspopup="true"
+                        aria-expanded={publishersOpen}
+                        onClick={() => setPublishersOpen((s) => !s)}
+                        className="text-soft-gray/70 hover:text-soft-gray p-1"
+                      >
+                        <ChevronDown className="w-4 h-4" />
+                      </button>
+                    </div>
+
+                    {/* Dropdown panel */}
+                    {publishersOpen && (
+                      <div
+                        ref={publishersRef}
+                        role="menu"
+                        aria-label="Publishers filters"
+                        className="absolute left-0 mt-2 w-56 bg-midnight-black/95 border border-soft-gray/10 rounded-lg shadow-lg py-2 z-50"
+                      >
+                        {publishersFilters.map((f) => (
+                          <Link
+                            key={f.label}
+                            to={f.href}
+                            role="menuitem"
+                            onClick={() => { try { window.analytics?.track('nav_publishers_filter', { category: f.category || 'All' }); } catch (e) {} setPublishersOpen(false); }}
+                            className="block px-4 py-2 text-soft-gray hover:text-electric-blue text-md"
+                          >
+                            <div className="flex justify-between items-center">
+                              <span>{f.label}</span>
+                              {typeof f.stat === 'number' && (
+                                <span className="ml-2 text-xs text-soft-gray/60">• {f.stat}</span>
+                              )}
+                            </div>
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              }
+
+              // Default link rendering
+              return (
+                <Link key={link.path} to={link.path} className={getLinkClasses(link.path)}>
+                  {link.label}
+                </Link>
+              );
+            })}
           </div>
 
           {/* Desktop CTA */}
@@ -174,16 +231,43 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
           <div className="fixed top-14 left-0 right-0 bg-midnight-black/95 backdrop-blur-md z-40 md:hidden">
             <div className="max-w-8xl mx-auto px-4 py-8">
               <div className="flex flex-col space-y-6">
-                {navigationLinks.map((link) => (
-                  <Link
-                    key={link.path}
-                    to={link.path}
-                    className="text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
-                    onClick={closeMenu}
-                  >
-                    {link.label}
-                  </Link>
-                ))}
+                {navigationLinks.map((link) => {
+                  if (link.path === '/publishers') {
+                    return (
+                      <div key="mobile-publishers" className="w-full">
+                        <button
+                          onClick={() => setMobilePublishersOpen((s) => !s)}
+                          className="w-full flex items-center justify-between text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
+                          aria-expanded={mobilePublishersOpen}
+                          aria-controls="mobile-publishers-panel"
+                        >
+                          <span>{link.label}</span>
+                          <ChevronRight className={`w-5 h-5 transform transition-transform ${mobilePublishersOpen ? 'rotate-90' : ''}`} />
+                        </button>
+                        {mobilePublishersOpen && (
+                          <div id="mobile-publishers-panel" className="pl-4 mt-2 space-y-2">
+                            {publishersFilters.map((f) => (
+                              <Link key={f.label} to={f.href} onClick={() => { closeMenu(); try { window.analytics?.track('nav_publishers_filter', { category: f.category || 'All' }); } catch(e) {} }} className="block text-soft-gray/80 hover:text-soft-gray py-2">
+                                {f.label}
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={link.path}
+                      to={link.path}
+                      className="text-soft-gray/80 hover:text-soft-gray transition-colors text-lg font-medium py-2"
+                      onClick={closeMenu}
+                    >
+                      {link.label}
+                    </Link>
+                  );
+                })}
 
                 {/* Mobile CTA */}
                 <div className="pt-6 border-t border-soft-gray/10">

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -61,6 +61,40 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
   // Choose which navigation links to show
   const navigationLinks = isAuthenticated ? authenticatedNavigationLinks : publicNavigationLinks;
 
+  // Publishers dropdown state and refs
+  const [publishersOpen, setPublishersOpen] = useState(false);
+  const [mobilePublishersOpen, setMobilePublishersOpen] = useState(false);
+  const publishersRef = useRef<HTMLDivElement | null>(null);
+
+  const publishersFilters = [
+    { label: "All Publishers", href: "/publishers", category: "All" },
+    { label: "Campus", href: "/publishers?category=Campus", category: "Campus" },
+    { label: "Local", href: "/publishers?category=Local", category: "Local" },
+    { label: "National", href: "/publishers?category=National", category: "National" },
+    { label: "Global", href: "/publishers?category=Global", category: "Global" },
+  ];
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (publishersRef.current && !publishersRef.current.contains(target)) {
+        setPublishersOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setPublishersOpen(false);
+        setMobilePublishersOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
   return (
     <nav className="bg-midnight-black/95 backdrop-blur-sm sticky top-0 z-50 border-b border-soft-gray/10">
       <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, User, LogOut, Settings, BarChart3 } from "lucide-react";

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, User, LogOut, Settings, BarChart3 } from "lucide-react";

--- a/client/pages/OurPublishers.tsx
+++ b/client/pages/OurPublishers.tsx
@@ -1,0 +1,158 @@
+import { useState, useMemo, useEffect } from "react";
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { Publisher, PublishersResponse, PublisherCategory } from "@shared/api";
+
+const categories: (PublisherCategory | "All")[] = ["All", "Campus", "Local", "National", "Global"];
+
+function useDebounced<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+export default function OurPublishers() {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounced(query, 300);
+  const [category, setCategory] = useState<PublisherCategory | "All">("All");
+
+  const fetchPage = async ({ pageParam = 0 }): Promise<PublishersResponse> => {
+    const params = new URLSearchParams();
+    params.set("cursor", String(pageParam));
+    params.set("limit", "30");
+    if (debouncedQuery) params.set("q", debouncedQuery);
+    if (category !== "All") params.set("category", category);
+    const res = await fetch(`/api/publishers?${params.toString()}`);
+    if (!res.ok) throw new Error("Failed to load publishers");
+    return res.json();
+  };
+
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ["publishers", { q: debouncedQuery, category }],
+    queryFn: fetchPage,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: 0,
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [debouncedQuery, category, refetch]);
+
+  const items = useMemo(() => (data ? data.pages.flatMap((p) => p.items) : []), [data]);
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "#1C2526" }}>
+      <Navigation />
+
+      <header className="pt-16 pb-10 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-8xl mx-auto">
+          <h1 className="text-4xl sm:text-5xl font-display font-bold text-soft-gray mb-3">Explore Our Publishers</h1>
+          <p className="text-soft-gray/80 text-lg">Hundreds of trusted local, campus, and global publications — all in one place.</p>
+        </div>
+      </header>
+
+      <section className="px-4 sm:px-6 lg:px-8">
+        <div className="max-w-8xl mx-auto">
+          {/* Controls */}
+          <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-6 mb-6">
+            <div className="flex-1">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search publishers…"
+                className="w-full rounded-full bg-gray-800/60 text-soft-gray placeholder:text-soft-gray/50 border border-soft-gray/10 px-5 py-3 focus:outline-none focus:ring-2 focus:ring-electric-blue focus:border-transparent"
+                aria-label="Search publishers"
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {categories.map((cat) => {
+                const active = category === cat;
+                return (
+                  <button
+                    key={cat}
+                    onClick={() => setCategory(cat as PublisherCategory | "All")}
+                    className={`px-4 py-2 rounded-full text-sm transition-colors border ${
+                      active
+                        ? "bg-electric-blue text-midnight-black border-electric-blue"
+                        : "bg-gray-800/40 text-soft-gray/80 hover:text-soft-gray border-soft-gray/10"
+                    }`}
+                  >
+                    {cat}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Grid */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-6">
+            {items.map((p: Publisher) => (
+              <PublisherCard key={p.id} publisher={p} />)
+            )}
+          </div>
+
+          {/* Load more */}
+          <div className="flex justify-center py-10">
+            {hasNextPage ? (
+              <Button onClick={() => fetchNextPage()} disabled={isFetchingNextPage} className="rounded-full">
+                {isFetchingNextPage ? "Loading…" : "Load More"}
+              </Button>
+            ) : (
+              !isLoading && <div className="text-soft-gray/60 text-sm">End of list</div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Footer */}
+      <section className="py-16">
+        <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-2xl sm:text-3xl font-display font-semibold text-soft-gray mb-4">
+            Want your publication on SpotlightNews? Join 400+ trusted partners.
+          </h2>
+          <Button asChild className="bg-electric-blue text-midnight-black hover:bg-cyan-400 rounded-full">
+            <a href="/onboarding">Become a Publisher</a>
+          </Button>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}
+
+function PublisherCard({ publisher }: { publisher: Publisher }) {
+  const logoUrl = `https://logo.clearbit.com/${publisher.domain}?size=200`;
+  return (
+    <div className="group relative rounded-xl overflow-hidden bg-gray-900/40 border border-soft-gray/10 p-4 flex flex-col items-center text-center transition-transform">
+      <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-md overflow-hidden mb-3">
+        <img
+          src={logoUrl}
+          alt={`${publisher.name} logo`}
+          className="w-full h-full object-contain filter grayscale contrast-125 opacity-80 transition duration-300 group-hover:grayscale-0 group-hover:opacity-100"
+        />
+      </div>
+      <div className="space-y-1">
+        <div className="text-soft-gray font-medium text-sm sm:text-base">{publisher.name}</div>
+        <div className="text-soft-gray/60 text-xs">{publisher.tagline || publisher.category}</div>
+      </div>
+      <div className="absolute inset-0 flex items-end justify-center p-4 opacity-0 group-hover:opacity-100 transition-opacity">
+        <Button asChild size="sm" className="rounded-full bg-electric-blue text-midnight-black hover:bg-cyan-400 shadow-lg">
+          <a href={`/explore?publisher=${encodeURIComponent(publisher.id)}`}>Read on Spotlight</a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/PublisherList.tsx
+++ b/client/pages/PublisherList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -8,10 +8,18 @@ import { Link } from "react-router-dom";
 const LIMIT = 30;
 
 export default function PublisherList() {
+  const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(q), 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
   const fetchPage = async ({ pageParam = 0 }) => {
     const params = new URLSearchParams();
     params.set("limit", String(LIMIT));
     params.set("cursor", String(pageParam));
+    if (debouncedQ) params.set("q", debouncedQ);
     const res = await fetch(`/api/publishers?${params.toString()}`);
     if (!res.ok) throw new Error("Failed to load publishers");
     return res.json();
@@ -26,11 +34,15 @@ export default function PublisherList() {
     isLoading,
     error,
   } = useInfiniteQuery({
-    queryKey: ["publisherList"],
+    queryKey: ["publisherList", debouncedQ],
     queryFn: fetchPage,
     getNextPageParam: (last) => last.nextCursor,
     initialPageParam: 0,
   });
+
+  useEffect(() => {
+    refetch();
+  }, [debouncedQ, refetch]);
 
   const items: Publisher[] = useMemo(() => (data ? data.pages.flatMap((p) => p.items) : []), [data]);
   const total = data?.pages?.[0]?.total ?? null;
@@ -61,6 +73,24 @@ export default function PublisherList() {
           <div className="text-sm text-soft-gray/70">{total !== null ? `${total} publishers` : 'Loading total...'}</div>
         </header>
 
+        {/* Hero + Search */}
+        <div className="mb-8 grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
+          <div className="md:col-span-2">
+            <p className="text-lg text-soft-gray/80 mb-3">Campus, local, and global newsrooms — all in one trusted feed.</p>
+            <div>
+              <input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search publishers..."
+                className="w-full rounded-md bg-gray-800/40 border border-soft-gray/10 text-soft-gray px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
+                aria-label="Search publishers"
+              />
+            </div>
+          </div>
+          <div className="md:col-span-1 flex justify-end">
+            <img src="https://placehold.co/320x160/png?text=Publishers+Hero" alt="Publishers hero" className="w-full max-w-sm rounded-lg object-cover shadow-md" />
+          </div>
+        </div>
 
         <section aria-live="polite">
           {isLoading && (

--- a/client/pages/PublisherList.tsx
+++ b/client/pages/PublisherList.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { Publisher } from "@shared/api";
+import { Link } from "react-router-dom";
+
+const LIMIT = 30;
+
+export default function PublisherList() {
+  const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState(q);
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(q), 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  const fetchPage = async ({ pageParam = 0 }) => {
+    const params = new URLSearchParams();
+    params.set("limit", String(LIMIT));
+    params.set("cursor", String(pageParam));
+    if (debouncedQ) params.set("q", debouncedQ);
+    const res = await fetch(`/api/publishers?${params.toString()}`);
+    if (!res.ok) throw new Error("Failed to load publishers");
+    return res.json();
+  };
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+    isLoading,
+    error,
+  } = useInfiniteQuery({
+    queryKey: ["publisherList", debouncedQ],
+    queryFn: fetchPage,
+    getNextPageParam: (last) => last.nextCursor,
+    initialPageParam: 0,
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [debouncedQ, refetch]);
+
+  const items: Publisher[] = useMemo(() => (data ? data.pages.flatMap((p) => p.items) : []), [data]);
+  const total = data?.pages?.[0]?.total ?? null;
+
+  // Infinite scroll sentinel
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    if (!('IntersectionObserver' in window)) return;
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+    });
+    io.observe(sentinelRef.current);
+    return () => io.disconnect();
+  }, [sentinelRef.current, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: '#1C2526' }}>
+      <Navigation />
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-soft-gray">
+        <header className="mb-6">
+          <h1 className="text-3xl font-display font-bold text-white mb-1">Publisher List</h1>
+          <div className="text-sm text-soft-gray/70">{total !== null ? `${total} publishers` : 'Loading total...'}</div>
+        </header>
+
+        <div className="mb-4">
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search publishers..."
+            className="w-full rounded-md bg-gray-800/40 border border-soft-gray/10 text-soft-gray px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
+            aria-label="Search publishers"
+          />
+        </div>
+
+        <section aria-live="polite">
+          {isLoading && (
+            <div className="space-y-3">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-4 py-3 border-b border-soft-gray/10">
+                  <div className="w-12 h-12 bg-gray-800 rounded-md animate-pulse" />
+                  <div className="flex-1">
+                    <div className="h-4 bg-gray-800 rounded w-1/3 animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!isLoading && error && (
+            <div className="text-center text-red-400 py-8">
+              <div>Error loading publishers.</div>
+              <button onClick={() => refetch()} className="mt-3 px-4 py-2 rounded-full bg-[#00C4CC] text-midnight-black">Retry</button>
+            </div>
+          )}
+
+          {!isLoading && !error && items.length === 0 && (
+            <div className="text-center py-16 text-soft-gray/70">No publishers match your filters.</div>
+          )}
+
+          {!isLoading && !error && items.length > 0 && (
+            <ul className="space-y-3">
+              {items.map((p) => {
+                const slug = (p as any).slug || p.id;
+                const logoUrl = (p as any).logoUrl || (p as any).domain ? `https://logo.clearbit.com/${(p as any).domain}?size=96` : null;
+                return (
+                  <li key={p.id} className="flex items-center gap-4 py-3 border-b border-soft-gray/10">
+                    <Link to={`/publisher/${slug}`} className="flex items-center gap-4 w-full">
+                      <div className="w-12 h-12 rounded-md bg-gray-800 flex items-center justify-center overflow-hidden">
+                        {logoUrl ? (
+                          <img src={logoUrl} alt={`${p.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
+                        ) : (
+                          <div className="text-sm font-medium text-soft-gray">{p.name.slice(0,2).toUpperCase()}</div>
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <div className="font-semibold text-soft-gray">{p.name}</div>
+                      </div>
+                    </Link>
+                    {(p as any).website && (
+                      <a href={(p as any).website} target="_blank" rel="noreferrer" className="text-soft-gray/60 hover:text-soft-gray px-2">🔗</a>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <div ref={sentinelRef} />
+
+          {!('IntersectionObserver' in window) && hasNextPage && (
+            <div className="flex justify-center py-6">
+              <button onClick={() => fetchNextPage()} disabled={isFetchingNextPage} className="px-4 py-2 rounded-full bg-[#00C4CC] text-midnight-black">
+                {isFetchingNextPage ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+
+          {('IntersectionObserver' in window) && isFetchingNextPage && (
+            <div className="text-center py-4 text-soft-gray/70">Loading more…</div>
+          )}
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/client/pages/PublisherList.tsx
+++ b/client/pages/PublisherList.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
 import React, { useEffect, useMemo, useRef } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";

--- a/client/pages/PublisherList.tsx
+++ b/client/pages/PublisherList.tsx
@@ -62,15 +62,6 @@ export default function PublisherList() {
           <div className="text-sm text-soft-gray/70">{total !== null ? `${total} publishers` : 'Loading total...'}</div>
         </header>
 
-        <div className="mb-4">
-          <input
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            placeholder="Search publishers..."
-            className="w-full rounded-md bg-gray-800/40 border border-soft-gray/10 text-soft-gray px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
-            aria-label="Search publishers"
-          />
-        </div>
 
         <section aria-live="polite">
           {isLoading && (

--- a/client/pages/PublisherList.tsx
+++ b/client/pages/PublisherList.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -8,18 +9,10 @@ import { Link } from "react-router-dom";
 const LIMIT = 30;
 
 export default function PublisherList() {
-  const [q, setQ] = useState("");
-  const [debouncedQ, setDebouncedQ] = useState(q);
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedQ(q), 250);
-    return () => clearTimeout(t);
-  }, [q]);
-
   const fetchPage = async ({ pageParam = 0 }) => {
     const params = new URLSearchParams();
     params.set("limit", String(LIMIT));
     params.set("cursor", String(pageParam));
-    if (debouncedQ) params.set("q", debouncedQ);
     const res = await fetch(`/api/publishers?${params.toString()}`);
     if (!res.ok) throw new Error("Failed to load publishers");
     return res.json();
@@ -34,15 +27,11 @@ export default function PublisherList() {
     isLoading,
     error,
   } = useInfiniteQuery({
-    queryKey: ["publisherList", debouncedQ],
+    queryKey: ["publisherList"],
     queryFn: fetchPage,
     getNextPageParam: (last) => last.nextCursor,
     initialPageParam: 0,
   });
-
-  useEffect(() => {
-    refetch();
-  }, [debouncedQ, refetch]);
 
   const items: Publisher[] = useMemo(() => (data ? data.pages.flatMap((p) => p.items) : []), [data]);
   const total = data?.pages?.[0]?.total ?? null;

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -65,13 +65,7 @@ export default function PublisherListStatic() {
 
       {/* Hero */}
       <div className="w-full relative">
-        <div
-          className="w-full h-[360px] bg-cover bg-center"
-          style={{
-            backgroundImage:
-              "linear-gradient(to bottom, rgba(0,0,0,0.6), rgba(0,0,0,0.15)), url('https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=1600')",
-          }}
-        />
+        <div className="w-full h-[360px]" style={{ backgroundColor: '#0b1f1f' }} />
         <div className="absolute inset-0 flex items-center">
           <div className="max-w-[840px] mx-auto px-6 py-8 text-center md:text-left">
             <h1 className="text-4xl md:text-5xl font-display font-bold text-white">Publisher Directory</h1>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -69,7 +69,7 @@ export default function PublisherListStatic() {
         <div className="absolute inset-0 flex items-center">
           <div className="max-w-[840px] mx-auto px-6 py-8 text-center md:text-left">
             <h1 className="text-4xl md:text-5xl font-display font-bold text-white">Publisher Directory</h1>
-            <h3 className="mt-3 text-lg text-soft-gray/80">Explore campus, local, and global newsrooms — all in one trusted feed.</h3>
+            <h3 className="mt-3 text-lg text-soft-gray/80">Discover publishers from campus papers to global newsrooms — all in one trusted place.</h3>
             <div className="mt-6">
               <a href="/signup" className="inline-block bg-[#00C4CC] text-white font-semibold px-5 py-3 rounded-full shadow">Create Free Account</a>
             </div>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -67,6 +67,16 @@ export default function PublisherListStatic() {
       <main>
         <div style={{ maxWidth: 1200, margin: '0 auto', padding: '24px 20px' }}>
           {/* Hero banner (above search row) */}
+          {/* Hero — solid color */}
+          <section style={{ marginBottom: 24 }}>
+            <div style={{ width: '100%', height: '38vh', minHeight: 320, maxHeight: 520, backgroundColor: '#0b1f1f', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 12 }}>
+              <div style={{ textAlign: 'center', padding: '0 20px' }}>
+                <h1 style={{ color: '#FFFFFF', fontSize: 36, fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
+                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8 }}>From your campus to the world — explore every newsroom in one feed.</p>
+              </div>
+            </div>
+          </section>
+
           {/* Search Row (sticky on mobile) */}
           <section>
             <div className="grid grid-cols-1 md:[grid-template-columns:1fr_220px]" style={{ gap: 12 }}>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -83,9 +83,6 @@ export default function PublisherListStatic() {
               <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '0 20px' }}>
                 <h1 style={{ color: '#FFFFFF', fontSize: '36px', fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
                 <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8, fontSize: 16 }}>From your campus to the world — explore every newsroom in one feed.</p>
-                <div style={{ marginTop: 16 }}>
-                  <a href="/signup" style={{ backgroundColor: '#00C4CC', color: '#FFFFFF', padding: '10px 18px', borderRadius: 999, display: 'inline-block', fontWeight: 600 }}>Create Free Account</a>
-                </div>
               </div>
             </div>
           </section>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -68,8 +68,8 @@ export default function PublisherListStatic() {
                 className="flex items-center gap-4 py-3 hover:bg-[rgba(0,196,204,0.06)]"
                 style={{ paddingTop: 12, paddingBottom: 12, borderBottom: '1px solid rgba(237,239,241,0.06)' }}
               >
-                <div className="w-14 h-14 rounded-full overflow-hidden flex-shrink-0" style={{ width: 56, height: 56 }}>
-                  <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
+                <div className="w-14 h-14 rounded-full bg-gray-800 flex items-center justify-center flex-shrink-0" style={{ width: 56, height: 56 }}>
+                  <span className="text-soft-gray font-medium">{item.name.split(' ').map(s=>s[0]).slice(0,2).join('').toUpperCase()}</span>
                 </div>
                 <div className="font-semibold">{item.name}</div>
               </div>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useRef, useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 const ITEMS = [
   { img: "https://placehold.co/96x96/svg?text=PI", name: "Philadelphia Inquirer" },
@@ -24,59 +25,138 @@ const ITEMS = [
   { img: "https://placehold.co/96x96/svg?text=SD", name: "The Stanford Daily" },
 ];
 
+function slugify(name: string) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
 export default function PublisherListStatic() {
   const [q, setQ] = useState("");
+  const [category, setCategory] = useState<"All" | "Campus" | "Local" | "National" | "Global">("All");
+  const [visible, setVisible] = useState(8);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
   const lower = q.trim().toLowerCase();
-  const items = useMemo(() => {
-    if (!lower) return ITEMS;
-    return ITEMS.filter((it) => it.name.toLowerCase().includes(lower));
-  }, [lower]);
+  const filtered = useMemo(() => {
+    let list = ITEMS.slice();
+    if (lower) list = list.filter((it) => it.name.toLowerCase().includes(lower));
+    // Static items don't have categories; if category != All we just simulate by name (no-op)
+    return list;
+  }, [lower, category]);
+
+  const visibleItems = filtered.slice(0, visible);
+  const hasMore = visible < filtered.length;
+
+  useEffect(() => {
+    if (!sentinelRef.current) return;
+    if (!('IntersectionObserver' in window)) return;
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasMore) {
+          setVisible((v) => Math.min(v + 8, filtered.length));
+        }
+      });
+    });
+    io.observe(sentinelRef.current);
+    return () => io.disconnect();
+  }, [sentinelRef.current, hasMore, filtered.length]);
 
   return (
-    <div style={{ backgroundColor: '#1C2526', color: '#EDEFF1' }} className="min-h-screen">
+    <div className="min-h-screen" style={{ backgroundColor: '#1C2526', color: '#FFFFFF' }}>
       <Navigation />
-      <main className="max-w-[840px] mx-auto p-6" style={{ padding: 24 }}>
-        <header className="mb-6 grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
-          <div className="md:col-span-2">
-            <h1 className="text-3xl font-display font-bold mb-2">Publisher List</h1>
-            <p className="text-soft-gray/80">Campus, local, and global newsrooms — all in one trusted feed.</p>
-            <div className="mt-4 max-w-md">
+
+      {/* Full-width hero */}
+      <div className="w-full relative">
+        <div
+          className="w-full h-44 md:h-64 bg-cover bg-center"
+          style={{
+            backgroundImage:
+              "linear-gradient(to bottom, rgba(12,14,15,0.65), rgba(12,14,15,0.2)), url('https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=1600')",
+          }}
+        />
+        <div className="absolute inset-0 flex items-center">
+          <div className="max-w-[840px] mx-auto px-6 py-6">
+            <h1 className="text-3xl md:text-4xl font-display font-bold text-white">Publisher Directory</h1>
+            <h3 className="mt-2 text-md text-soft-gray/80">Explore campus, local, and global newsrooms — all in one trusted feed.</h3>
+            <div className="mt-4">
+              <Button onClick={() => { try { window.analytics?.track('cta_create_account'); } catch(e){} }} className="bg-[#00C4CC] text-midnight-black">
+                Create Free Account
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-[840px] mx-auto p-6 mt-6" style={{ padding: 24 }}>
+        {/* Search + Filters */}
+        <div className="sticky top-16 bg-transparent z-10">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+            <div className="flex-1">
               <input
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
                 placeholder="Search publishers..."
-                className="w-full rounded-md bg-gray-800/40 border border-soft-gray/10 text-soft-gray px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
+                className="w-full rounded-md bg-gray-800/30 border border-soft-gray/10 text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
                 aria-label="Search publishers"
               />
             </div>
-          </div>
 
-          <div className="md:col-span-1 flex justify-end">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=800"
-              alt="Publishers hero"
-              className="w-full max-w-sm rounded-lg object-cover shadow-md"
-            />
+            <div className="mt-3 md:mt-0 flex items-center gap-2 flex-wrap">
+              {(["All", "Campus", "Local", "National", "Global"] as const).map((c) => (
+                <button
+                  key={c}
+                  onClick={() => setCategory(c)}
+                  aria-pressed={category === c}
+                  className={`px-3 py-2 rounded-full text-sm font-medium ${category === c ? 'bg-[#00C4CC] text-midnight-black' : 'bg-gray-800/30 text-white hover:bg-gray-800/40'}`}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
           </div>
-        </header>
+        </div>
 
+        {/* Grid */}
         <section>
-          <div className="flex flex-col">
-            {items.map((item, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-4 py-3 hover:bg-[rgba(0,196,204,0.06)]"
-                style={{ paddingTop: 12, paddingBottom: 12, borderBottom: '1px solid rgba(237,239,241,0.06)' }}
-              >
-                <div className="w-14 h-14 rounded-full bg-gray-800 flex items-center justify-center flex-shrink-0" style={{ width: 56, height: 56 }}>
-                  <span className="text-soft-gray font-medium">{item.name.split(' ').map(s=>s[0]).slice(0,2).join('').toUpperCase()}</span>
-                </div>
-                <div className="font-semibold">{item.name}</div>
-              </div>
-            ))}
-          </div>
+          {visibleItems.length === 0 ? (
+            <div className="py-20 text-center text-soft-gray/70">
+              <div className="mb-4">No publishers found. Try another filter.</div>
+              <div className="mx-auto w-40 h-24 bg-gray-800 rounded-md" />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {visibleItems.map((item) => {
+                const slug = slugify(item.name);
+                return (
+                  <Link to={`/publisher/${slug}`} key={item.name} className="block">
+                    <div className="bg-[#0e1414] rounded-2xl p-4 shadow-md transform transition hover:scale-[1.02] hover:shadow-lg" style={{ borderRadius: '1rem' }}>
+                      <div className="flex items-center gap-4">
+                        <div className="w-12 h-12 rounded-full bg-gray-800 flex items-center justify-center overflow-hidden">
+                          <span className="text-soft-gray font-medium">{item.name.split(' ').map(s=>s[0]).slice(0,2).join('').toUpperCase()}</span>
+                        </div>
+                        <div className="flex-1">
+                          <div className="font-semibold text-white truncate">{item.name}</div>
+                          <div className="text-sm text-soft-gray/70 truncate">{item.tagline || ''}</div>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+
+          <div ref={sentinelRef} />
+
+          {hasMore && (
+            <div className="flex justify-center mt-8">
+              <button onClick={() => setVisible((v) => Math.min(v + 8, filtered.length))} className="px-4 py-2 rounded-full bg-[#00C4CC] text-midnight-black">
+                Load more
+              </button>
+            </div>
+          )}
         </section>
       </main>
+
       <Footer />
     </div>
   );

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -2,27 +2,26 @@ import React, { useMemo, useState, useRef, useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 
 const ITEMS = [
-  { img: "https://placehold.co/96x96/svg?text=PI", name: "Philadelphia Inquirer" },
-  { img: "https://placehold.co/96x96/svg?text=B", name: "Bloomberg" },
-  { img: "https://placehold.co/96x96/svg?text=R", name: "Reuters" },
-  { img: "https://placehold.co/96x96/svg?text=F", name: "Forbes" },
-  { img: "https://placehold.co/96x96/svg?text=CDT", name: "Centre Daily Times" },
-  { img: "https://placehold.co/96x96/svg?text=TN", name: "Temple News" },
-  { img: "https://placehold.co/96x96/svg?text=B%26W", name: "The Brown and White (Lehigh)" },
-  { img: "https://placehold.co/96x96/svg?text=JH", name: "The Johns Hopkins News-Letter" },
-  { img: "https://placehold.co/96x96/svg?text=SN", name: "The State News (MSU)" },
-  { img: "https://placehold.co/96x96/svg?text=DP", name: "The Daily Pennsylvanian" },
-  { img: "https://placehold.co/96x96/svg?text=HC", name: "The Harvard Crimson" },
-  { img: "https://placehold.co/96x96/svg?text=YDN", name: "Yale Daily News" },
-  { img: "https://placehold.co/96x96/svg?text=DC", name: "The Daily Californian" },
-  { img: "https://placehold.co/96x96/svg?text=TL", name: "The Lantern (Ohio State)" },
-  { img: "https://placehold.co/96x96/svg?text=TMD", name: "The Michigan Daily" },
-  { img: "https://placehold.co/96x96/svg?text=DB", name: "The Diamondback (Maryland)" },
-  { img: "https://placehold.co/96x96/svg?text=DN", name: "The Daily Northwestern" },
-  { img: "https://placehold.co/96x96/svg?text=SD", name: "The Stanford Daily" },
+  { img: "https://placehold.co/96x96/svg?text=PI", name: "Philadelphia Inquirer", tagline: "Local journalism in Philly" },
+  { img: "https://placehold.co/96x96/svg?text=B", name: "Bloomberg", tagline: "Business & markets" },
+  { img: "https://placehold.co/96x96/svg?text=R", name: "Reuters", tagline: "Global news" },
+  { img: "https://placehold.co/96x96/svg?text=F", name: "Forbes", tagline: "Business insights" },
+  { img: "https://placehold.co/96x96/svg?text=CDT", name: "Centre Daily Times", tagline: "State news" },
+  { img: "https://placehold.co/96x96/svg?text=TN", name: "Temple News", tagline: "Campus reporting" },
+  { img: "https://placehold.co/96x96/svg?text=B%26W", name: "The Brown and White (Lehigh)", tagline: "Campus news" },
+  { img: "https://placehold.co/96x96/svg?text=JH", name: "The Johns Hopkins News-Letter", tagline: "University coverage" },
+  { img: "https://placehold.co/96x96/svg?text=SN", name: "The State News (MSU)", tagline: "Campus news" },
+  { img: "https://placehold.co/96x96/svg?text=DP", name: "The Daily Pennsylvanian", tagline: "University reporting" },
+  { img: "https://placehold.co/96x96/svg?text=HC", name: "The Harvard Crimson", tagline: "Campus journalism" },
+  { img: "https://placehold.co/96x96/svg?text=YDN", name: "Yale Daily News", tagline: "Campus journalism" },
+  { img: "https://placehold.co/96x96/svg?text=DC", name: "The Daily Californian", tagline: "Campus news" },
+  { img: "https://placehold.co/96x96/svg?text=TL", name: "The Lantern (Ohio State)", tagline: "Campus reporting" },
+  { img: "https://placehold.co/96x96/svg?text=TMD", name: "The Michigan Daily", tagline: "Campus news" },
+  { img: "https://placehold.co/96x96/svg?text=DB", name: "The Diamondback (Maryland)", tagline: "Campus coverage" },
+  { img: "https://placehold.co/96x96/svg?text=DN", name: "The Daily Northwestern", tagline: "Campus reporting" },
+  { img: "https://placehold.co/96x96/svg?text=SD", name: "The Stanford Daily", tagline: "Campus journalism" },
 ];
 
 function slugify(name: string) {
@@ -39,7 +38,7 @@ export default function PublisherListStatic() {
   const filtered = useMemo(() => {
     let list = ITEMS.slice();
     if (lower) list = list.filter((it) => it.name.toLowerCase().includes(lower));
-    // Static items don't have categories; if category != All we just simulate by name (no-op)
+    // For static demo, we won't filter by category (no category data)
     return list;
   }, [lower, category]);
 
@@ -64,53 +63,52 @@ export default function PublisherListStatic() {
     <div className="min-h-screen" style={{ backgroundColor: '#1C2526', color: '#FFFFFF' }}>
       <Navigation />
 
-      {/* Full-width hero */}
+      {/* Hero */}
       <div className="w-full relative">
         <div
-          className="w-full h-44 md:h-64 bg-cover bg-center"
+          className="w-full h-[360px] bg-cover bg-center"
           style={{
             backgroundImage:
-              "linear-gradient(to bottom, rgba(12,14,15,0.65), rgba(12,14,15,0.2)), url('https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=1600')",
+              "linear-gradient(to bottom, rgba(0,0,0,0.6), rgba(0,0,0,0.15)), url('https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=1600')",
           }}
         />
         <div className="absolute inset-0 flex items-center">
-          <div className="max-w-[840px] mx-auto px-6 py-6">
-            <h1 className="text-3xl md:text-4xl font-display font-bold text-white">Publisher Directory</h1>
-            <h3 className="mt-2 text-md text-soft-gray/80">Explore campus, local, and global newsrooms — all in one trusted feed.</h3>
-            <div className="mt-4">
-              <Button onClick={() => { try { window.analytics?.track('cta_create_account'); } catch(e){} }} className="bg-[#00C4CC] text-midnight-black">
-                Create Free Account
-              </Button>
+          <div className="max-w-[840px] mx-auto px-6 py-8 text-center md:text-left">
+            <h1 className="text-4xl md:text-5xl font-display font-bold text-white">Publisher Directory</h1>
+            <h3 className="mt-3 text-lg text-soft-gray/80">Explore campus, local, and global newsrooms — all in one trusted feed.</h3>
+            <div className="mt-6">
+              <a href="/signup" className="inline-block bg-[#00C4CC] text-white font-semibold px-5 py-3 rounded-full shadow">Create Free Account</a>
             </div>
           </div>
         </div>
       </div>
 
-      <main className="max-w-[840px] mx-auto p-6 mt-6" style={{ padding: 24 }}>
-        {/* Search + Filters */}
-        <div className="sticky top-16 bg-transparent z-10">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+      <main className="max-w-[840px] mx-auto p-6 mt-6 space-y-6" style={{ padding: 24 }}>
+        {/* Search + Filter */}
+        <div className="w-full">
+          <div className="flex flex-col md:flex-row items-center gap-4">
             <div className="flex-1">
               <input
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
                 placeholder="Search publishers..."
-                className="w-full rounded-md bg-gray-800/30 border border-soft-gray/10 text-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
+                className="w-full rounded-md bg-[#17201f] border border-[#223232] text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
                 aria-label="Search publishers"
               />
             </div>
-
-            <div className="mt-3 md:mt-0 flex items-center gap-2 flex-wrap">
-              {(["All", "Campus", "Local", "National", "Global"] as const).map((c) => (
-                <button
-                  key={c}
-                  onClick={() => setCategory(c)}
-                  aria-pressed={category === c}
-                  className={`px-3 py-2 rounded-full text-sm font-medium ${category === c ? 'bg-[#00C4CC] text-midnight-black' : 'bg-gray-800/30 text-white hover:bg-gray-800/40'}`}
-                >
-                  {c}
-                </button>
-              ))}
+            <div className="w-full md:w-56">
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as any)}
+                className="w-full rounded-md bg-[#17201f] border border-[#223232] text-white px-4 py-3"
+                aria-label="Filter by category"
+              >
+                <option>All</option>
+                <option>Campus</option>
+                <option>Local</option>
+                <option>National</option>
+                <option>Global</option>
+              </select>
             </div>
           </div>
         </div>
@@ -119,26 +117,29 @@ export default function PublisherListStatic() {
         <section>
           {visibleItems.length === 0 ? (
             <div className="py-20 text-center text-soft-gray/70">
-              <div className="mb-4">No publishers found. Try another filter.</div>
-              <div className="mx-auto w-40 h-24 bg-gray-800 rounded-md" />
+              <div className="mx-auto mb-6 w-40 h-24 bg-[#17201f] rounded-md" />
+              <div className="text-lg">No publishers found. Try another filter.</div>
             </div>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {visibleItems.map((item) => {
                 const slug = slugify(item.name);
                 return (
                   <Link to={`/publisher/${slug}`} key={item.name} className="block">
-                    <div className="bg-[#0e1414] rounded-2xl p-4 shadow-md transform transition hover:scale-[1.02] hover:shadow-lg" style={{ borderRadius: '1rem' }}>
-                      <div className="flex items-center gap-4">
-                        <div className="w-12 h-12 rounded-full bg-gray-800 flex items-center justify-center overflow-hidden">
-                          <span className="text-soft-gray font-medium">{item.name.split(' ').map(s=>s[0]).slice(0,2).join('').toUpperCase()}</span>
+                    <article
+                      className="bg-[#1C2526] rounded-2xl p-4 shadow-sm transform transition-all hover:scale-105"
+                      style={{ boxShadow: '0 6px 18px rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.02)' }}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="w-12 h-12 rounded-full bg-[#0f1414] flex items-center justify-center flex-shrink-0">
+                          <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
                         </div>
-                        <div className="flex-1">
-                          <div className="font-semibold text-white truncate">{item.name}</div>
-                          <div className="text-sm text-soft-gray/70 truncate">{item.tagline || ''}</div>
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-semibold text-white truncate">{item.name}</h4>
+                          <p className="text-sm text-soft-gray/70 truncate">{item.tagline}</p>
                         </div>
                       </div>
-                    </div>
+                    </article>
                   </Link>
                 );
               })}
@@ -148,8 +149,8 @@ export default function PublisherListStatic() {
           <div ref={sentinelRef} />
 
           {hasMore && (
-            <div className="flex justify-center mt-8">
-              <button onClick={() => setVisible((v) => Math.min(v + 8, filtered.length))} className="px-4 py-2 rounded-full bg-[#00C4CC] text-midnight-black">
+            <div className="flex justify-center mt-6">
+              <button onClick={() => setVisible((v) => Math.min(v + 8, filtered.length))} className="px-4 py-2 rounded-full bg-[#00C4CC] text-white">
                 Load more
               </button>
             </div>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -115,7 +115,7 @@ export default function PublisherListStatic() {
               <div className="text-lg">No publishers found. Try another filter.</div>
             </div>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
               {visibleItems.map((item) => {
                 const slug = slugify(item.name);
                 return (

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
@@ -25,20 +25,47 @@ const ITEMS = [
 ];
 
 export default function PublisherListStatic() {
+  const [q, setQ] = useState("");
+  const lower = q.trim().toLowerCase();
+  const items = useMemo(() => {
+    if (!lower) return ITEMS;
+    return ITEMS.filter((it) => it.name.toLowerCase().includes(lower));
+  }, [lower]);
+
   return (
     <div style={{ backgroundColor: '#1C2526', color: '#EDEFF1' }} className="min-h-screen">
       <Navigation />
       <main className="max-w-[840px] mx-auto p-6" style={{ padding: 24 }}>
-        <header className="mb-4">
-          <h1 className="text-3xl font-display font-bold mb-2">Publisher List</h1>
+        <header className="mb-6 grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
+          <div className="md:col-span-2">
+            <h1 className="text-3xl font-display font-bold mb-2">Publisher List</h1>
+            <p className="text-soft-gray/80">Campus, local, and global newsrooms — all in one trusted feed.</p>
+            <div className="mt-4 max-w-md">
+              <input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search publishers..."
+                className="w-full rounded-md bg-gray-800/40 border border-soft-gray/10 text-soft-gray px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
+                aria-label="Search publishers"
+              />
+            </div>
+          </div>
+
+          <div className="md:col-span-1 flex justify-end">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2Ff9a2587e1b874b6e9d34bfb6b703b455%2F93f590eec3684d129be0a4d274bd2174?format=webp&width=800"
+              alt="Publishers hero"
+              className="w-full max-w-sm rounded-lg object-cover shadow-md"
+            />
+          </div>
         </header>
 
         <section>
           <div className="flex flex-col">
-            {ITEMS.map((item, idx) => (
+            {items.map((item, idx) => (
               <div
                 key={idx}
-                className="flex items-center gap-4 py-3"
+                className="flex items-center gap-4 py-3 hover:bg-[rgba(0,196,204,0.06)]"
                 style={{ paddingTop: 12, paddingBottom: 12, borderBottom: '1px solid rgba(237,239,241,0.06)' }}
               >
                 <div className="w-14 h-14 rounded-full overflow-hidden flex-shrink-0" style={{ width: 56, height: 56 }}>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -70,9 +70,9 @@ export default function PublisherListStatic() {
           {/* Hero — solid color */}
           <section style={{ marginBottom: 24 }}>
             <div style={{ width: '100%', height: '38vh', minHeight: 320, maxHeight: 520, backgroundColor: '#0b1f1f', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 12 }}>
-              <div style={{ textAlign: 'center', padding: '0 20px' }}>
-                <h1 style={{ color: '#FFFFFF', fontSize: 36, fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
-                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8 }}>Meet the publishers who power Spotlight — from campus newsrooms to global outlets.</p>
+              <div style={{ textAlign: 'center', padding: '0 20px' }} className="relative z-20 mx-auto max-w-8xl">
+                <h1 className="text-6xl sm:text-7xl lg:text-8xl font-display font-bold mb-4 leading-[0.85] tracking-tight text-white">Publisher Directory</h1>
+                <p className="text-2xl sm:text-3xl text-soft-gray/80 mb-2 font-light leading-relaxed">Meet the publishers who power Spotlight — from campus newsrooms to global outlets.</p>
               </div>
             </div>
           </section>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -72,7 +72,7 @@ export default function PublisherListStatic() {
             <div style={{ width: '100%', height: '38vh', minHeight: 320, maxHeight: 520, backgroundColor: '#0b1f1f', display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 12 }}>
               <div style={{ textAlign: 'center', padding: '0 20px' }}>
                 <h1 style={{ color: '#FFFFFF', fontSize: 36, fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
-                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8 }}>From your campus to the world — explore every newsroom in one feed.</p>
+                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8 }}>Meet the publishers who power Spotlight — from campus newsrooms to global outlets.</p>
               </div>
             </div>
           </section>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -121,11 +121,11 @@ export default function PublisherListStatic() {
                 return (
                   <Link to={`/publisher/${slug}`} key={item.name} className="block">
                     <article
-                      className="bg-[#1C2526] rounded-2xl p-4 shadow-sm transform transition-all hover:scale-105"
-                      style={{ boxShadow: '0 6px 18px rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.02)' }}
+                      className="bg-[#1C2526] rounded-2xl p-6 shadow-sm transform transition-all hover:scale-105 hover:border-[rgba(0,196,204,0.12)]"
+                      style={{ boxShadow: '0 8px 24px rgba(0,0,0,0.45)', border: '1px solid rgba(255,255,255,0.02)', minHeight: 96 }}
                     >
-                      <div className="flex items-start gap-3">
-                        <div className="w-12 h-12 rounded-full bg-[#0f1414] flex items-center justify-center flex-shrink-0">
+                      <div className="flex items-center gap-4">
+                        <div className="w-14 h-14 rounded-full bg-[#0f1414] flex items-center justify-center flex-shrink-0">
                           <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
                         </div>
                         <div className="flex-1 min-w-0">

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -77,79 +77,97 @@ export default function PublisherListStatic() {
         </div>
       </div>
 
-      <main className="max-w-[840px] mx-auto p-6 mt-6 space-y-6" style={{ padding: 24 }}>
-        {/* Search + Filter */}
-        <div className="w-full">
-          <div className="flex flex-col md:flex-row items-center gap-4">
-            <div className="flex-1">
-              <input
-                value={q}
-                onChange={(e) => setQ(e.target.value)}
-                placeholder="Search publishers..."
-                className="w-full rounded-md bg-[#17201f] border border-[#223232] text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#00C4CC]"
-                aria-label="Search publishers"
-              />
+      <main>
+        <div style={{ maxWidth: 1200, margin: '0 auto', padding: '24px 20px' }}>
+          {/* Hero banner (above search row) */}
+          <section style={{ height: '38vh', minHeight: 320, maxHeight: 520, position: 'relative', marginBottom: 24, borderRadius: 12, overflow: 'hidden', backgroundSize: 'cover', backgroundPosition: 'center', backgroundImage: "url('https://placehold.co/1600x900/png?text=Hero')" }}>
+            <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,.45) 0%, rgba(0,0,0,.15) 100%)' }} />
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center' }}>
+              <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '0 20px' }}>
+                <h1 style={{ color: '#FFFFFF', fontSize: '36px', fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
+                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8, fontSize: 16 }}>From your campus to the world — explore every newsroom in one feed.</p>
+                <div style={{ marginTop: 16 }}>
+                  <a href="/signup" style={{ backgroundColor: '#00C4CC', color: '#FFFFFF', padding: '10px 18px', borderRadius: 999, display: 'inline-block', fontWeight: 600 }}>Create Free Account</a>
+                </div>
+              </div>
             </div>
-            <div className="w-full md:w-56">
-              <select
-                value={category}
-                onChange={(e) => setCategory(e.target.value as any)}
-                className="w-full rounded-md bg-[#17201f] border border-[#223232] text-white px-4 py-3"
-                aria-label="Filter by category"
-              >
-                <option>All</option>
-                <option>Campus</option>
-                <option>Local</option>
-                <option>National</option>
-                <option>Global</option>
-              </select>
-            </div>
-          </div>
-        </div>
+          </section>
 
-        {/* Grid */}
-        <section>
-          {visibleItems.length === 0 ? (
-            <div className="py-20 text-center text-soft-gray/70">
-              <div className="mx-auto mb-6 w-40 h-24 bg-[#17201f] rounded-md" />
-              <div className="text-lg">No publishers found. Try another filter.</div>
+          {/* Search Row (sticky on mobile) */}
+          <section>
+            <div className="grid grid-cols-1 md:[grid-template-columns:1fr_220px]" style={{ gap: 12 }}>
+              <div style={{ position: 'relative' }}>
+                <div className="md:hidden sticky top-0 z-50" style={{ backdropFilter: 'blur(6px)', background: 'rgba(28,37,38,0.8)', padding: '8px 0' }} />
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 12 }}>
+                  <input
+                    value={q}
+                    onChange={(e) => setQ(e.target.value)}
+                    placeholder="Search publishers..."
+                    aria-label="Search publishers"
+                    style={{ width: '100%', padding: '12px 14px', borderRadius: 8, background: '#17201f', border: '1px solid #223232', color: '#FFFFFF' }}
+                  />
+                  <select
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value as any)}
+                    aria-label="Filter by category"
+                    style={{ width: '100%', padding: '12px 14px', borderRadius: 8, background: '#17201f', border: '1px solid #223232', color: '#FFFFFF' }}
+                  >
+                    <option>All</option>
+                    <option>Campus</option>
+                    <option>Local</option>
+                    <option>National</option>
+                    <option>Global</option>
+                  </select>
+                </div>
+              </div>
             </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {visibleItems.map((item) => {
-                const slug = slugify(item.name);
-                return (
-                  <Link to={`/publisher/${slug}`} key={item.name} className="block">
-                    <article
-                      className="bg-[#1C2526] rounded-2xl p-6 shadow-sm transform transition-all hover:scale-105 hover:border-[rgba(0,196,204,0.12)]"
-                      style={{ boxShadow: '0 8px 24px rgba(0,0,0,0.45)', border: '1px solid rgba(255,255,255,0.02)', minHeight: 96 }}
-                    >
-                      <div className="flex items-center gap-4">
-                        <div className="w-14 h-14 rounded-full bg-[#0f1414] flex items-center justify-center flex-shrink-0">
-                          <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
+          </section>
+
+          {/* Publisher Grid */}
+          <section style={{ marginTop: 16 }}>
+            {visibleItems.length === 0 ? (
+              <div style={{ padding: '48px 0', textAlign: 'center' }}>
+                <div style={{ width: 120, height: 72, background: '#17201f', margin: '0 auto 16px', borderRadius: 8 }} />
+                <h3 style={{ color: '#FFFFFF', fontSize: 20, marginBottom: 8 }}>No publishers found</h3>
+                <p style={{ color: '#B8C5C6' }}>Try a different search or filter.</p>
+              </div>
+            ) : (
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 18 }}>
+                {visibleItems.map((item) => {
+                  const slug = slugify(item.name);
+                  return (
+                    <Link to={`/publisher/${slug}`} key={item.name} className="block" style={{ textDecoration: 'none' }}>
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        style={{ display: 'flex', alignItems: 'center', gap: 12, padding: 16, minHeight: 104, background: '#0F1516', borderRadius: 16, boxShadow: '0 6px 14px rgba(0,0,0,0.25)', transition: 'transform 160ms ease, box-shadow 160ms ease' }}
+                        className="publisher-card"
+                      >
+                        <div style={{ width: 56, height: 56, borderRadius: 12, background: '#222C2D', color: '#D9DFE0', fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', flexShrink: 0 }}>
+                          <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" width={56} height={56} style={{ objectFit: 'cover', width: '100%', height: '100%' }} />
                         </div>
-                        <div className="flex-1 min-w-0">
-                          <h4 className="font-semibold text-white truncate">{item.name}</h4>
-                          <p className="text-sm text-soft-gray/70 truncate">{item.tagline}</p>
+                        <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+                          <h6 title={item.name} style={{ fontSize: 16, fontWeight: 600, lineHeight: 1.2, margin: 0, color: '#FFFFFF', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{item.name}</h6>
+                          <div style={{ color: '#B8C5C6', fontSize: 13, lineHeight: '1.35', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical', display: '-webkit-box', overflow: 'hidden', marginTop: 6 }}>{item.tagline}</div>
                         </div>
                       </div>
-                    </article>
-                  </Link>
-                );
-              })}
-            </div>
-          )}
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
 
-          <div ref={sentinelRef} />
+            <div ref={sentinelRef} />
 
-          {hasMore && (
-            <div className="flex justify-center mt-6">
-              <button onClick={() => setVisible((v) => Math.min(v + 8, filtered.length))} className="px-4 py-2 rounded-full bg-[#00C4CC] text-white">
-                Load more
-              </button>
-            </div>
-          )}
-        </section>
+            {hasMore && (
+              <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
+                <button onClick={() => setVisible((v) => Math.min(v + 8, filtered.length))} style={{ padding: '10px 16px', borderRadius: 999, background: '#00C4CC', color: '#FFFFFF', border: 'none' }}>
+                  Load more
+                </button>
+              </div>
+            )}
+          </section>
+        </div>
       </main>
 
       <Footer />

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -63,30 +63,10 @@ export default function PublisherListStatic() {
     <div className="min-h-screen" style={{ backgroundColor: '#1C2526', color: '#FFFFFF' }}>
       <Navigation />
 
-      {/* Hero */}
-      <div className="w-full relative">
-        <div className="w-full h-[360px]" style={{ backgroundColor: '#0b1f1f' }} />
-        <div className="absolute inset-0 flex items-center">
-          <div className="max-w-[840px] mx-auto px-6 py-8 text-center md:text-left">
-            <h1 className="text-4xl md:text-5xl font-display font-bold text-white">Publisher Directory</h1>
-            <h3 className="mt-3 text-lg text-soft-gray/80">Discover publishers from campus papers to global newsrooms — all in one trusted place.</h3>
-          </div>
-        </div>
-      </div>
 
       <main>
         <div style={{ maxWidth: 1200, margin: '0 auto', padding: '24px 20px' }}>
           {/* Hero banner (above search row) */}
-          <section style={{ height: '38vh', minHeight: 320, maxHeight: 520, position: 'relative', marginBottom: 24, borderRadius: 12, overflow: 'hidden', backgroundSize: 'cover', backgroundPosition: 'center', backgroundImage: "url('https://placehold.co/1600x900/png?text=Hero')" }}>
-            <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,.45) 0%, rgba(0,0,0,.15) 100%)' }} />
-            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center' }}>
-              <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '0 20px' }}>
-                <h1 style={{ color: '#FFFFFF', fontSize: '36px', fontWeight: 700, margin: 0 }}>Publisher Directory</h1>
-                <p style={{ color: '#FFFFFF', opacity: 0.85, marginTop: 8, fontSize: 16 }}>From your campus to the world — explore every newsroom in one feed.</p>
-              </div>
-            </div>
-          </section>
-
           {/* Search Row (sticky on mobile) */}
           <section>
             <div className="grid grid-cols-1 md:[grid-template-columns:1fr_220px]" style={{ gap: 12 }}>

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import { Link } from "react-router-dom";
+
+const ITEMS = [
+  { img: "https://placehold.co/96x96/svg?text=PI", name: "Philadelphia Inquirer" },
+  { img: "https://placehold.co/96x96/svg?text=B", name: "Bloomberg" },
+  { img: "https://placehold.co/96x96/svg?text=R", name: "Reuters" },
+  { img: "https://placehold.co/96x96/svg?text=F", name: "Forbes" },
+  { img: "https://placehold.co/96x96/svg?text=CDT", name: "Centre Daily Times" },
+  { img: "https://placehold.co/96x96/svg?text=TN", name: "Temple News" },
+  { img: "https://placehold.co/96x96/svg?text=B%26W", name: "The Brown and White (Lehigh)" },
+  { img: "https://placehold.co/96x96/svg?text=JH", name: "The Johns Hopkins News-Letter" },
+  { img: "https://placehold.co/96x96/svg?text=SN", name: "The State News (MSU)" },
+  { img: "https://placehold.co/96x96/svg?text=DP", name: "The Daily Pennsylvanian" },
+  { img: "https://placehold.co/96x96/svg?text=HC", name: "The Harvard Crimson" },
+  { img: "https://placehold.co/96x96/svg?text=YDN", name: "Yale Daily News" },
+  { img: "https://placehold.co/96x96/svg?text=DC", name: "The Daily Californian" },
+  { img: "https://placehold.co/96x96/svg?text=TL", name: "The Lantern (Ohio State)" },
+  { img: "https://placehold.co/96x96/svg?text=TMD", name: "The Michigan Daily" },
+  { img: "https://placehold.co/96x96/svg?text=DB", name: "The Diamondback (Maryland)" },
+  { img: "https://placehold.co/96x96/svg?text=DN", name: "The Daily Northwestern" },
+  { img: "https://placehold.co/96x96/svg?text=SD", name: "The Stanford Daily" },
+];
+
+export default function PublisherListStatic() {
+  return (
+    <div style={{ backgroundColor: '#1C2526', color: '#EDEFF1' }} className="min-h-screen">
+      <Navigation />
+      <main className="max-w-[840px] mx-auto p-6" style={{ padding: 24 }}>
+        <header className="mb-4">
+          <h1 className="text-3xl font-display font-bold mb-2">Publisher List</h1>
+        </header>
+
+        <section>
+          <div className="flex flex-col">
+            {ITEMS.map((item, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-4 py-3"
+                style={{ paddingTop: 12, paddingBottom: 12, borderBottom: '1px solid rgba(237,239,241,0.06)' }}
+              >
+                <div className="w-14 h-14 rounded-full overflow-hidden flex-shrink-0" style={{ width: 56, height: 56 }}>
+                  <img src={item.img} alt={`${item.name} logo`} loading="lazy" decoding="async" className="w-full h-full object-contain" />
+                </div>
+                <div className="font-semibold">{item.name}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/client/pages/PublisherListStatic.tsx
+++ b/client/pages/PublisherListStatic.tsx
@@ -70,9 +70,6 @@ export default function PublisherListStatic() {
           <div className="max-w-[840px] mx-auto px-6 py-8 text-center md:text-left">
             <h1 className="text-4xl md:text-5xl font-display font-bold text-white">Publisher Directory</h1>
             <h3 className="mt-3 text-lg text-soft-gray/80">Discover publishers from campus papers to global newsrooms — all in one trusted place.</h3>
-            <div className="mt-6">
-              <a href="/signup" className="inline-block bg-[#00C4CC] text-white font-semibold px-5 py-3 rounded-full shadow">Create Free Account</a>
-            </div>
           </div>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,17 @@
     "": {
       "name": "fusion-starter",
       "dependencies": {
+        "@radix-ui/react-aspect-ratio": "^1.1.7",
+        "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
@@ -737,6 +741,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -750,6 +760,56 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1125,6 +1185,129 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1281,10 +1464,43 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2902,6 +3118,34 @@
       "integrity": "sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5469,6 +5713,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-aspect-ratio": "^1.1.7",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:full": "vite",
     "build": "vite build",
     "build:client": "vite build",
     "preview": "vite preview"

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -11,3 +11,19 @@ export interface DemoResponse {
   message: string;
   timestamp?: string;
 }
+
+export type PublisherCategory = "Campus" | "Local" | "National" | "Global";
+
+export interface Publisher {
+  id: string;
+  name: string;
+  domain: string;
+  category: PublisherCategory;
+  tagline?: string;
+}
+
+export interface PublishersResponse {
+  items: Publisher[];
+  nextCursor: number | null;
+  total: number;
+}


### PR DESCRIPTION
## Purpose

The user requested a complete redesign of the publisher listing functionality with specific UI requirements. They wanted to:
- Update the hero text from "Explore campus, local, and global newsrooms" to "Meet the publishers who power Spotlight — from campus newsrooms to global outlets"
- Create a new publisher directory page with a hero banner, search functionality, and grid layout
- Style the hero text to match the Students and About pages
- Remove the "Create Free Account" CTA from the publisher list
- Add a solid color hero image for the Publisher tab

## Code changes

- **New API endpoint**: Added `/api/publishers.ts` with mock publisher data supporting search, filtering by category (Campus/Local/National/Global), and pagination
- **New pages**: Created `OurPublishers.tsx`, `PublisherList.tsx`, and `PublisherListStatic.tsx` components with hero sections, search bars, category filters, and responsive grid layouts
- **Navigation updates**: Added new publisher-related routes to the app router and navigation menu
- **Dependencies**: Added Radix UI components for select dropdowns, avatars, and aspect ratios, plus Embla carousel for potential future use
- **Shared types**: Added TypeScript interfaces for `Publisher`, `PublisherCategory`, and `PublishersResponse` in shared API types
- **Styling**: Implemented hero sections with solid backgrounds, search/filter controls, and card-based publisher grid layouts matching the requested design specificationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0c64aee1baa741caaba58922dbcbd47f/main)

👀 [Preview Link](https://0c64aee1baa741caaba58922dbcbd47f-main.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0c64aee1baa741caaba58922dbcbd47f</projectId>-->
<!--<branchName>main</branchName>-->