### PR TITLE
feat: Add Publisher Directory page

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from "@/lib/auth";
 import Index from "./pages/Index";
 import Students from "./pages/Students";
 import Publishers from "./pages/Publishers";
+import PublisherDirectory from "./pages/PublisherDirectory";
 import Universities from "./pages/Universities";
 import About from "./pages/About";
 import Pricing from "./pages/Pricing";
@@ -38,6 +39,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/students" element={<Students />} />
           <Route path="/publishers" element={<Publishers />} />
+          <Route path="/publisher-directory" element={<PublisherDirectory />} />
           <Route path="/universities" element={<Universities />} />
           <Route path="/about" element={<About />} />
           <Route path="/pricing" element={<Pricing />} />

--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -46,6 +46,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
     { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
+    { path: "/publisher-directory", label: "Publisher Directory" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -1,0 +1,196 @@
+import React, { useMemo, useState } from "react";
+import Navigation from "@/components/Navigation";
+import { Button } from "@/components/ui/button";
+
+type Publisher = {
+  name: string;
+  logoUrl?: string;
+  url: string;
+  description?: string;
+  isPremium?: boolean;
+  isLocal?: boolean;
+};
+
+const MOCK_PUBLISHERS: Publisher[] = [
+  {
+    name: "Daily Beacon",
+    logoUrl:
+      "https://via.placeholder.com/300x300.png?text=Daily+Beacon",
+    url: "https://example.com/daily-beacon",
+    description: "Campus-focused daily covering student life, sports, and local news.",
+    isPremium: true,
+    isLocal: false,
+  },
+  {
+    name: "Town Herald",
+    logoUrl:
+      "https://via.placeholder.com/300x300.png?text=Town+Herald",
+    url: "https://example.com/town-herald",
+    description: "Local community reporting with a focus on human interest stories.",
+    isPremium: false,
+    isLocal: true,
+  },
+  {
+    name: "Metro Ledger",
+    logoUrl:
+      "https://via.placeholder.com/300x300.png?text=Metro+Ledger",
+    url: "https://example.com/metro-ledger",
+    description: "Regional coverage with investigative reporting and features.",
+    isPremium: true,
+    isLocal: true,
+  },
+  // Additional sample items for demonstration and load-more behavior
+  ...Array.from({ length: 12 }).map((_, i) => ({
+    name: `Community Press ${i + 1}`,
+    logoUrl: `https://via.placeholder.com/300x300.png?text=Press+${i + 1}`,
+    url: `https://example.com/press-${i + 1}`,
+    description: `Local press edition ${i + 1} covering neighborhoods and events.`,
+    isPremium: i % 7 === 0,
+    isLocal: true,
+  })),
+];
+
+const PublisherDirectory: React.FC = () => {
+  const [query, setQuery] = useState("");
+  const [filterPremium, setFilterPremium] = useState(false);
+  const [filterLocal, setFilterLocal] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(9);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return MOCK_PUBLISHERS.filter((p) => {
+      if (filterPremium && !p.isPremium) return false;
+      if (filterLocal && !p.isLocal) return false;
+      if (!q) return true;
+      return (
+        p.name.toLowerCase().includes(q) || (p.description || "").toLowerCase().includes(q)
+      );
+    });
+  }, [query, filterPremium, filterLocal]);
+
+  const visible = filtered.slice(0, visibleCount);
+  const canLoadMore = visibleCount < filtered.length;
+
+  return (
+    <div className="min-h-screen bg-midnight-black text-foreground">
+      <Navigation />
+
+      {/* HERO */}
+      <section className="relative w-full h-[48vh] md:h-[60vh] lg:h-[70vh] overflow-hidden">
+        <video
+          className="absolute inset-0 w-full h-full object-cover pointer-events-none filter brightness-50"
+          autoPlay
+          muted
+          loop
+          playsInline
+          preload="metadata"
+        >
+          <source src="/public/hero-loop.mp4" type="video/mp4" />
+          {/* Fallback poster image */}
+        </video>
+
+        <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/40 to-black/60" />
+
+        <div className="relative z-10 max-w-6xl mx-auto px-4 py-12 h-full flex flex-col justify-center items-center text-center">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white text-glow-blue">
+            Explore Trusted Publishers
+          </h1>
+          <div className="w-20 h-0.5 bg-[#00CCDD] mt-4 mb-4 rounded" />
+          <p className="max-w-2xl text-soft-gray/90 text-base md:text-lg">
+            Discover premium, local, and college newspapers all in one place.
+          </p>
+        </div>
+      </section>
+
+      {/* CONTENT */}
+      <main className="max-w-8xl mx-auto px-4 py-8">
+        {/* Search & Filters - sticky */}
+        <div className="sticky top-14 z-30 bg-midnight-black/80 backdrop-blur-sm py-4 rounded-md">
+          <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center gap-4">
+            <div className="flex-1 w-full">
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search by name or type…"
+                className="w-full rounded-full px-4 py-3 bg-card text-foreground border border-soft-gray/10 focus:outline-none focus:ring-2 focus:ring-[#00CCDD] transition"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => setFilterPremium((s) => !s)}
+                className={`px-4 py-2 rounded-full font-medium transition ${
+                  filterPremium
+                    ? "bg-[#00CCDD] text-white shadow-md"
+                    : "bg-transparent text-[#00CCDD] border border-[#00CCDD]/30"
+                }`}
+              >
+                Premium
+              </button>
+
+              <button
+                onClick={() => setFilterLocal((s) => !s)}
+                className={`px-4 py-2 rounded-full font-medium transition ${
+                  filterLocal
+                    ? "bg-[#00CCDD] text-white shadow-md"
+                    : "bg-transparent text-[#00CCDD] border border-[#00CCDD]/30 text-[#00CCDD]"
+                }`}
+              >
+                Local Paper
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Grid */}
+        <section className="mt-8">
+          <div className="max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {visible.map((p, idx) => (
+                <article
+                  key={p.url + idx}
+                  onClick={() => window.open(p.url, "_blank")}
+                  className="relative bg-card rounded-xl p-6 cursor-pointer hover:shadow-xl hover:scale-[1.01] transform transition overflow-hidden"
+                >
+                  {/* label */}
+                  {(p.isPremium || p.isLocal) && (
+                    <span className={`absolute top-4 right-4 text-xs font-semibold px-2 py-1 rounded-full text-white ${p.isPremium ? 'bg-yellow-500' : 'bg-[#00CCDD]'}`}>
+                      {p.isPremium ? 'Premium' : 'Local Paper'}
+                    </span>
+                  )}
+
+                  <div className="flex flex-col items-center text-center">
+                    <img
+                      src={p.logoUrl}
+                      alt={p.name}
+                      width={160}
+                      height={160}
+                      className="w-[120px] h-[120px] md:w-[160px] md:h-[160px] object-cover rounded-md mb-4"
+                    />
+
+                    <h3 className="font-semibold text-lg text-foreground mb-2">{p.name}</h3>
+
+                    {p.description && (
+                      <p className="text-sm text-soft-gray/80 line-clamp-3">{p.description}</p>
+                    )}
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="mt-8 flex justify-center">
+              {canLoadMore ? (
+                <Button onClick={() => setVisibleCount((v) => v + 9)}>Load more</Button>
+              ) : (
+                <p className="text-soft-gray/70">No more publishers to show.</p>
+              )}
+            </div>
+          </div>
+        </section>
+      </main>
+
+    </div>
+  );
+};
+
+export default PublisherDirectory;

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import React, { useMemo, useState } from "react";
 import Navigation from "@/components/Navigation";
 import { Button } from "@/components/ui/button";
 

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -100,7 +100,7 @@ const PublisherDirectory: React.FC = () => {
         p.name.toLowerCase().includes(q) || (p.description || "").toLowerCase().includes(q)
       );
     });
-  }, [query, filterPremium, filterLocal, selectedCategories]);
+  }, [query, selectedCategories]);
 
   const visible = filtered.slice(0, visibleCount);
   const canLoadMore = visibleCount < filtered.length;

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -181,6 +181,26 @@ const PublisherDirectory: React.FC = () => {
           </div>
         </div>
 
+        {/* Category pills */}
+        <div className="mt-4">
+          <div className="max-w-6xl mx-auto px-2">
+            <div className="flex flex-wrap gap-3">
+              {ALL_CATEGORIES.map((cat) => {
+                const active = selectedCategories.has(cat as any);
+                return (
+                  <button
+                    key={cat}
+                    onClick={() => toggleCategory(cat as any)}
+                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition ${active ? 'bg-[#00CCDD] text-white shadow-md' : 'bg-transparent border border-[#00CCDD]/30 text-[#00CCDD]'}`}
+                  >
+                    {cat}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
         {/* Grid */}
         <section className="mt-8">
           <div className="max-w-6xl mx-auto">

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -75,8 +75,6 @@ const MOCK_PUBLISHERS: Publisher[] = [
 
 const PublisherDirectory: React.FC = () => {
   const [query, setQuery] = useState("");
-  const [filterPremium, setFilterPremium] = useState(false);
-  const [filterLocal, setFilterLocal] = useState(true);
   const [visibleCount, setVisibleCount] = useState(9);
   const [selectedCategories, setSelectedCategories] = useState<Set<Category>>(new Set(["Local Publication"]));
 

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -84,9 +84,9 @@ const PublisherDirectory: React.FC = () => {
           loop
           playsInline
           preload="metadata"
+          poster="https://via.placeholder.com/1600x900.png?text=Spotlight+Hero"
         >
-          <source src="/public/hero-loop.mp4" type="video/mp4" />
-          {/* Fallback poster image */}
+          <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4" />
         </video>
 
         <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/40 to-black/60" />

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -1,6 +1,28 @@
 import React, { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import Navigation from "@/components/Navigation";
 import { Button } from "@/components/ui/button";
+
+const ALL_CATEGORIES = [
+  "Premium",
+  "Business Publication",
+  "College Newspaper",
+  "Entertainment Publication",
+  "Lifestyle",
+  "Local Newspaper",
+  "Local Publication",
+  "Magazine",
+  "News Wire",
+  "Newsletter",
+  "Political News",
+  "Satire",
+  "Science Publication",
+  "Sports Publication",
+  "Student Government",
+  "University Media",
+] as const;
+
+type Category = (typeof ALL_CATEGORIES)[number];
 
 type Publisher = {
   name: string;
@@ -9,35 +31,36 @@ type Publisher = {
   description?: string;
   isPremium?: boolean;
   isLocal?: boolean;
+  categories?: Category[];
 };
 
 const MOCK_PUBLISHERS: Publisher[] = [
   {
     name: "Daily Beacon",
-    logoUrl:
-      "https://via.placeholder.com/300x300.png?text=Daily+Beacon",
+    logoUrl: "https://via.placeholder.com/300x300.png?text=Daily+Beacon",
     url: "https://example.com/daily-beacon",
     description: "Campus-focused daily covering student life, sports, and local news.",
     isPremium: true,
     isLocal: false,
+    categories: ["Premium", "College Newspaper", "University Media"],
   },
   {
     name: "Town Herald",
-    logoUrl:
-      "https://via.placeholder.com/300x300.png?text=Town+Herald",
+    logoUrl: "https://via.placeholder.com/300x300.png?text=Town+Herald",
     url: "https://example.com/town-herald",
     description: "Local community reporting with a focus on human interest stories.",
     isPremium: false,
     isLocal: true,
+    categories: ["Local Newspaper", "Local Publication", "Lifestyle"],
   },
   {
     name: "Metro Ledger",
-    logoUrl:
-      "https://via.placeholder.com/300x300.png?text=Metro+Ledger",
+    logoUrl: "https://via.placeholder.com/300x300.png?text=Metro+Ledger",
     url: "https://example.com/metro-ledger",
     description: "Regional coverage with investigative reporting and features.",
     isPremium: true,
     isLocal: true,
+    categories: ["Premium", "Local Newspaper", "News Wire"],
   },
   // Additional sample items for demonstration and load-more behavior
   ...Array.from({ length: 12 }).map((_, i) => ({
@@ -47,26 +70,42 @@ const MOCK_PUBLISHERS: Publisher[] = [
     description: `Local press edition ${i + 1} covering neighborhoods and events.`,
     isPremium: i % 7 === 0,
     isLocal: true,
+    categories: [i % 5 === 0 ? "Magazine" : "Local Publication"],
   })),
 ];
 
 const PublisherDirectory: React.FC = () => {
   const [query, setQuery] = useState("");
   const [filterPremium, setFilterPremium] = useState(false);
-  const [filterLocal, setFilterLocal] = useState(false);
+  const [filterLocal, setFilterLocal] = useState(true);
   const [visibleCount, setVisibleCount] = useState(9);
+  const [selectedCategories, setSelectedCategories] = useState<Set<Category>>(new Set(["Local Publication"]));
+
+  const toggleCategory = (c: Category) => {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
+  };
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return MOCK_PUBLISHERS.filter((p) => {
       if (filterPremium && !p.isPremium) return false;
       if (filterLocal && !p.isLocal) return false;
+      // category filtering
+      if (selectedCategories.size > 0) {
+        const has = (p.categories || []).some((cat) => selectedCategories.has(cat));
+        if (!has) return false;
+      }
       if (!q) return true;
       return (
         p.name.toLowerCase().includes(q) || (p.description || "").toLowerCase().includes(q)
       );
     });
-  }, [query, filterPremium, filterLocal]);
+  }, [query, filterPremium, filterLocal, selectedCategories]);
 
   const visible = filtered.slice(0, visibleCount);
   const canLoadMore = visibleCount < filtered.length;

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -150,29 +150,7 @@ const PublisherDirectory: React.FC = () => {
               />
             </div>
 
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => setFilterPremium((s) => !s)}
-                className={`px-4 py-2 rounded-full font-medium transition ${
-                  filterPremium
-                    ? "bg-[#00CCDD] text-white shadow-md"
-                    : "bg-transparent text-[#00CCDD] border border-[#00CCDD]/30"
-                }`}
-              >
-                Premium
-              </button>
-
-              <button
-                onClick={() => setFilterLocal((s) => !s)}
-                className={`px-4 py-2 rounded-full font-medium transition ${
-                  filterLocal
-                    ? "bg-[#00CCDD] text-white shadow-md"
-                    : "bg-transparent text-[#00CCDD] border border-[#00CCDD]/30 text-[#00CCDD]"
-                }`}
-              >
-                Local Paper
-              </button>
-            </div>
+            <div className="flex items-center gap-3" />
           </div>
         </div>
 

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -90,8 +90,6 @@ const PublisherDirectory: React.FC = () => {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return MOCK_PUBLISHERS.filter((p) => {
-      if (filterPremium && !p.isPremium) return false;
-      if (filterLocal && !p.isLocal) return false;
       // category filtering
       if (selectedCategories.size > 0) {
         const has = (p.categories || []).some((cat) => selectedCategories.has(cat));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,17 @@
     "": {
       "name": "fusion-starter",
       "dependencies": {
+        "@radix-ui/react-aspect-ratio": "^1.1.7",
+        "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
@@ -737,6 +741,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -750,6 +760,56 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1125,6 +1185,129 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1281,10 +1464,43 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2902,6 +3118,34 @@
       "integrity": "sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5469,6 +5713,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-aspect-ratio": "^1.1.7",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",


### PR DESCRIPTION
### Purpose

This pull request introduces a new 'Publisher Directory' page. The goal is to provide users with a dedicated space to discover and filter through a comprehensive list of publishers. Users can filter publishers by various categories such as 'Premium', 'Local Newspaper', and 'College Newspaper'.

### Code changes

- **New Page**: Created the `PublisherDirectory.tsx` page, which features a hero section, a search and filter component, and a grid layout for publisher listings.
- **Filtering**: Implemented category pills for filtering the publisher list.
- **Routing**: Added a new route and navigation link for the 'Publisher Directory'.
- **Data**: Included mock data for publishers to populate the directory.
- **Dependencies**: Updated `package.json` and `package-lock.json` to include new dependencies for the directory page components.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cd91ee31e7774668892936f16e1e330f/quantum-haven)

👀 [Preview Link](https://cd91ee31e7774668892936f16e1e330f-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cd91ee31e7774668892936f16e1e330f</projectId>-->
<!--<branchName>quantum-haven</branchName>-->