### PR TITLE
feat: Update text on Publisher Directory page

### DIFF
--- a/client/components/Navigation.tsx
+++ b/client/components/Navigation.tsx
@@ -46,7 +46,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentPage }) => {
     { path: "/publishers", label: "Publishers" },
     { path: "/universities", label: "Colleges/Universities" },
     { path: "/pricing", label: "Pricing" },
-    { path: "/publisher-directory", label: "Publisher Directory" },
+    { path: "/publisher-directory", label: "Our Publishers" },
     { path: "/about", label: "About" },
   ];
 

--- a/client/pages/PublisherDirectory.tsx
+++ b/client/pages/PublisherDirectory.tsx
@@ -127,7 +127,7 @@ const PublisherDirectory: React.FC = () => {
 
         <div className="relative z-10 max-w-6xl mx-auto px-4 py-12 h-full flex flex-col justify-center items-center text-center">
           <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-white text-glow-blue">
-            Explore Trusted Publishers
+            Explore Current Spotlight Publishers
           </h1>
           <div className="w-20 h-0.5 bg-[#00CCDD] mt-4 mb-4 rounded" />
           <p className="max-w-2xl text-soft-gray/90 text-base md:text-lg">

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:full": "vite",
     "build": "vite build",
     "build:client": "vite build",
     "preview": "vite preview"


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal was to update the text on the publisher directory page to be more descriptive and current. The user requested changing the main navigation link and the page's primary header.

### Code changes

- `client/components/Navigation.tsx`: The navigation item label was changed from "Publisher Directory" to "Our Publishers".
- `client/pages/PublisherDirectory.tsx`: The main heading was updated from "Explore Trusted Publishers" to "Explore Current Spotlight Publishers".
- `package.json`: A new `dev:full` script was added.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d4fb94e4f301491eac93b5b403df462a/main)

👀 [Preview Link](https://d4fb94e4f301491eac93b5b403df462a-main.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d4fb94e4f301491eac93b5b403df462a</projectId>-->
<!--<branchName>main</branchName>-->